### PR TITLE
Hard coded 'php' command changed to PHP_BINARY

### DIFF
--- a/Command/RunCommand.php
+++ b/Command/RunCommand.php
@@ -301,7 +301,7 @@ class RunCommand extends \Symfony\Bundle\FrameworkBundle\Command\ContainerAwareC
         }
 
         $pb
-            ->add('php')
+            ->add(PHP_BINARY)
             ->add($console)
             ->add('--env='.$this->env)
         ;


### PR DESCRIPTION
Hard coded 'php' command changed to PHP_BINARY to execute command from same php version.

Issue come when user's system is having different php version and jobqueue is running on different php version, Job command is using system's php version instead of using same php version where it executed.

For example:
We are running eo job queue from php 7.0.1 version and our system by default php version is 5.5. So it execute our project job using php5.5 instead of 7.0.1.